### PR TITLE
Pin cosign-installer to v4.1.1

### DIFF
--- a/.github/workflows/push-artifact.yaml
+++ b/.github/workflows/push-artifact.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install flux
         uses: controlplaneio-fluxcd/distribution/actions/setup@main
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.1
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/release-artifact.yaml
+++ b/.github/workflows/release-artifact.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install flux
         uses: controlplaneio-fluxcd/distribution/actions/setup@main
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.1
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
- The v4 moving tag does not exist in sigstore/cosign-installer (only v4.0.0, v4.1.0, v4.1.1 are published)
- Pin to v4.1.1 so GitHub Actions can resolve the reference

## Test plan
- [ ] push-artifact and release-artifact workflows run successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)